### PR TITLE
Add EditorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+# top-most EditorConfig file
+root = true
+
+[*.cs]
+indent_style = space
+indent_size = 2

--- a/Last.fm-Scrubbler-WPF.sln
+++ b/Last.fm-Scrubbler-WPF.sln
@@ -7,6 +7,11 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Last.fm-Scrubbler-WPF", "La
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Last.fm-Scrubbler-WPF-Test", "Last.fm-Scrubbler-WPF-Test\Last.fm-Scrubbler-WPF-Test.csproj", "{8528C039-46C3-43FF-A6B1-69423B7C0F8F}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{75D2E963-1F06-4FC6-A8D3-8BAC5C4D6A4C}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU


### PR DESCRIPTION
More information [here](https://editorconfig.org/) and [here](https://docs.microsoft.com/en-us/visualstudio/ide/create-portable-custom-editor-options).

Due to the fact that this project uses an unusual 2 spaces indent size, Visual Studio's default settings for C# causes it to edit every line when formatting a document. This file is read by Visual Studio 2017 and ensures style consistency for contributors.