### PR TITLE
Checkbox to split "Artist - Track" automatically in Manual Scrobbler

### DIFF
--- a/Last.fm-Scrubbler-WPF/Scrobbling/Scrobbler/ManualScrobbleView.xaml
+++ b/Last.fm-Scrubbler-WPF/Scrobbling/Scrobbler/ManualScrobbleView.xaml
@@ -26,16 +26,20 @@
       <RowDefinition Height="*"/>
       <RowDefinition Height="Auto"/>
     </Grid.RowDefinitions>
-    <Grid.ColumnDefinitions>
-      <ColumnDefinition Width="Auto"/>
-      <ColumnDefinition Width="5"/>
-      <ColumnDefinition Width="*"/>
-      <ColumnDefinition Width="5"/>
-      <ColumnDefinition Width="Auto"/>
-    </Grid.ColumnDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="5"/>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="5"/>
+            <ColumnDefinition Width="Auto"/>
+        </Grid.ColumnDefinitions>
 
     <Label Grid.Row="0" Grid.Column="0" Content="Artist:"/>
-    <TextBox Grid.Row="0" Grid.Column="2" Grid.ColumnSpan="3" Text="{Binding Artist, UpdateSourceTrigger=PropertyChanged}"/>
+    <TextBox Grid.Row="0" Grid.Column="2" Text="{Binding Artist, UpdateSourceTrigger=PropertyChanged}"/>
+      
+    <CheckBox Grid.Row="0" Grid.Column="4" Content="Split 'Artist - Track'"
+        IsChecked="{Binding SplitArtistTrack, UpdateSourceTrigger=PropertyChanged}"
+        VerticalAlignment="Center"/>
 
     <Label Grid.Row="2" Grid.Column="0" Content="Track:"/>
     <TextBox Grid.Row="2" Grid.Column="2" Grid.ColumnSpan="3" Text="{Binding Track, UpdateSourceTrigger=PropertyChanged}"/>

--- a/Last.fm-Scrubbler-WPF/Scrobbling/Scrobbler/ManualScrobbleView.xaml
+++ b/Last.fm-Scrubbler-WPF/Scrobbling/Scrobbler/ManualScrobbleView.xaml
@@ -26,13 +26,13 @@
       <RowDefinition Height="*"/>
       <RowDefinition Height="Auto"/>
     </Grid.RowDefinitions>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto"/>
-            <ColumnDefinition Width="5"/>
-            <ColumnDefinition Width="*"/>
-            <ColumnDefinition Width="5"/>
-            <ColumnDefinition Width="Auto"/>
-        </Grid.ColumnDefinitions>
+    <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="Auto"/>
+        <ColumnDefinition Width="5"/>
+        <ColumnDefinition Width="*"/>
+        <ColumnDefinition Width="5"/>
+        <ColumnDefinition Width="Auto"/>
+    </Grid.ColumnDefinitions>
 
     <Label Grid.Row="0" Grid.Column="0" Content="Artist:"/>
     <TextBox Grid.Row="0" Grid.Column="2" Text="{Binding Artist, UpdateSourceTrigger=PropertyChanged}"/>

--- a/Last.fm-Scrubbler-WPF/Scrobbling/Scrobbler/ManualScrobbleViewModel.cs
+++ b/Last.fm-Scrubbler-WPF/Scrobbling/Scrobbler/ManualScrobbleViewModel.cs
@@ -26,6 +26,13 @@ namespace Scrubbler.Scrobbling.Scrobbler
         _scrobbleFeature.Artist = value;
         NotifyOfPropertyChange();
         NotifyCanProperties();
+
+        // Split if the split checkbox is active
+        if (SplitArtistTrack)
+        {
+          SplitArtistField();
+        }
+
       }
     }
 
@@ -190,5 +197,43 @@ namespace Scrubbler.Scrobbling.Scrobbler
       NotifyOfPropertyChange(nameof(CanScrobble));
       NotifyOfPropertyChange(nameof(CanPreview));
     }
+
+    private bool _splitArtistTrack;
+    /// <summary>
+    /// If true, the content of the Artist field will be automatically split into 'Artist - Track'.
+    /// </summary>
+    public bool SplitArtistTrack
+    {
+      get => _splitArtistTrack;
+      set
+      {
+        if (_splitArtistTrack != value)
+        {
+          _splitArtistTrack = value;
+          NotifyOfPropertyChange();
+          if (_splitArtistTrack)
+          {
+            SplitArtistField();
+          }
+        }
+      }
+    }
+
+    /// <summary>
+    /// Splits the Artist field content into 'Artist - Track'.
+    /// </summary>
+    private void SplitArtistField()
+    {
+      if (string.IsNullOrWhiteSpace(Artist))
+        return;
+
+      var parts = Artist.Split(new[] { '-' }, 2);
+      if (parts.Length == 2)
+      {
+        Artist = parts[0].Trim();
+        Track = parts[1].Trim();
+      }
+    }
+
   }
 }


### PR DESCRIPTION
- Checkbox splits when "Artist - Track" is activated.
- Artist field calls the split function when SplitArtistTrack is true.
- Grid adapted for checkbox.